### PR TITLE
Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "eawfoc_mod_generator"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 
 [dependencies]
 clap = { version = "4.5.20", features = ["derive"] }


### PR DESCRIPTION
note: tested for changes and nothing was suggested

Rust version now set to 1.85

closes (#1)